### PR TITLE
Match build.sbt imports to Example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,10 @@ scalaVersion := "2.13.7"
 console / initialCommands := """
       |import doodle.core._
       |import doodle.image._
-      |import doodle.image.syntax._
+      |import doodle.image.syntax.all._
       |import doodle.image.syntax.core._
       |import doodle.java2d._
+      |import cats.effect.unsafe.implicits.global
     """.trim.stripMargin
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
23d4241 updated some imports but build.sbt is still using the old ones. This updates build.sbt to match what's in Example.scala.

This also addresses #4. 