### PR TITLE
Remove -XX:+CMSClassUnloadingEnabled option

### DIFF
--- a/sbt.bat
+++ b/sbt.bat
@@ -1,1 +1,1 @@
-java -Xmx3g -Xms1g -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -XX:+UseNUMA -XX:+UseParallelGC -XX:+CMSClassUnloadingEnabled -jar sbt-launch.jar %*
+java -Xmx3g -Xms1g -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -XX:+UseNUMA -XX:+UseParallelGC -jar sbt-launch.jar %*

--- a/sbt.sh
+++ b/sbt.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-java -Xmx3g -Xms1g -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -XX:+UseNUMA -XX:+UseParallelGC -XX:+CMSClassUnloadingEnabled -jar sbt-launch.jar "$@"
+java -Xmx3g -Xms1g -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -XX:+UseNUMA -XX:+UseParallelGC -jar sbt-launch.jar "$@"


### PR DESCRIPTION
This option is no longer supported in Java 14 and later. The `java` command fails to start when it is passed.

Since Java 8, this option is enabled by default, so it is safe to leave it out.